### PR TITLE
Rewrite publish-bridge and add systemd boot service

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,8 +22,8 @@ shellcheck:
     TESTBED_REPO: https://github.com/fepitre/qubes-bridge-device-tests.git
     TESTBED_DIR: /tmp/bridge-device-tests
     ADMIN_SRC: /tmp/bridge-device-admin
-    ADMIN_REPO_URL: ""
-    ADMIN_BRANCH: ""
+    ADMIN_REPO_URL: "https://github.com/fepitre/qubes-core-admin-addon-bridge-device.git"
+    ADMIN_BRANCH: "devel20260416"
   before_script:
     - sudo qubes-dom0-update -y ansible qubes-ansible-dom0
     - sudo qvm-run --pass-io -u root "$(qvm-prefs default-mgmt-dvm template)" "dnf install -y qubes-ansible qubes-ansible-vm"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,54 @@
 include:
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-base.yml'
+    file: '/r4.3/gitlab-base.yml'
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-vm.yml'
+    file: '/r4.3/gitlab-vm.yml'
+
+shellcheck:
+  image: fedora:latest
+  stage: checks
+  tags:
+    - docker
+  before_script:
+    - sudo dnf install -y ShellCheck git
+  script:
+    - shellcheck -x -e SC1117 $(grep -l '^#!/bin/\(ba\)\?sh' $(git ls-files))
+
+.bridge-device-integration:
+  stage: checks
+  tags:
+    - vm-kvm
+  variables:
+    TESTBED_REPO: https://github.com/fepitre/qubes-bridge-device-tests.git
+    TESTBED_DIR: /tmp/bridge-device-tests
+    ADMIN_SRC: /tmp/bridge-device-admin
+    ADMIN_REPO_URL: ""
+    ADMIN_BRANCH: ""
+  before_script:
+    - sudo qubes-dom0-update -y ansible qubes-ansible-dom0
+    - sudo qvm-run --pass-io -u root "$(qvm-prefs default-mgmt-dvm template)" "dnf install -y qubes-ansible qubes-ansible-vm"
+    - sudo qvm-shutdown --wait "$(qvm-prefs default-mgmt-dvm template)"
+  script:
+    - git clone --depth 1 "$TESTBED_REPO" "$TESTBED_DIR"
+    - |
+      ADMIN_REPO="${ADMIN_REPO_URL:-$CI_SERVER_URL/$CI_PROJECT_NAMESPACE/qubes-core-admin-addon-bridge-device.git}"
+      ADMIN_REF="${ADMIN_BRANCH:-$CI_COMMIT_BRANCH}"
+      git clone --branch "$ADMIN_REF" --depth 1 "$ADMIN_REPO" "$ADMIN_SRC"
+    - cd "$TESTBED_DIR"
+    - >
+      ansible-playbook playbooks/main.yml
+      -e core_admin_src="$ADMIN_SRC"
+      -e core_agent_src="$CI_PROJECT_DIR"
+    - >
+      ansible-playbook playbooks/deploy.yml
+      -e core_admin_src="$ADMIN_SRC"
+      -e core_agent_src="$CI_PROJECT_DIR"
+    - >
+      ansible-playbook playbooks/tests.yml
+      -e core_admin_src="$ADMIN_SRC"
+      -e core_agent_src="$CI_PROJECT_DIR"
+
+r4.3:bridge-device-integration:
+  extends: .bridge-device-integration
+  variables:
+    VM_IMAGE: qubes_4.3_64bit_stable.qcow2

--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -1,0 +1,7 @@
+vm:
+  rpm:
+    build:
+    - rpm_spec/qubes-core-agent-linux-bridge-device.spec
+  deb:
+    build:
+    - debian

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,24 @@
+UNITDIR ?= /usr/lib/systemd/system
+
 all:
 	@true
-install-common:
-	mkdir -p $(DESTDIR)/usr/lib/qubes/
-	install network/publish-bridge $(DESTDIR)/usr/lib/qubes/
 
-install-networking:
-	install -d $(DESTDIR)/etc/network/if-up.d/
-	install -d $(DESTDIR)/etc/network/if-down.d/
-	ln -sf /usr/lib/qubes/publish-bridge $(DESTDIR)/etc/network/if-up.d/
-	ln -sf /usr/lib/qubes/publish-bridge $(DESTDIR)/etc/network/if-down.d/
+install-common:
+	install -d $(DESTDIR)/usr/lib/qubes
+	install -m 0755 network/publish-bridge $(DESTDIR)/usr/lib/qubes/
+	install -m 0755 network/harden-bridge  $(DESTDIR)/usr/lib/qubes/
 
 install-networkmanager:
-	install -d $(DESTDIR)/etc/NetworkManager/dispatcher.d/pre-up.d/
-	install -d $(DESTDIR)/etc/NetworkManager/dispatcher.d/pre-down.d/
-	ln -sf /usr/lib/qubes/publish-bridge $(DESTDIR)/etc/NetworkManager/dispatcher.d/pre-up.d/
-	ln -sf /usr/lib/qubes/publish-bridge $(DESTDIR)/etc/NetworkManager/dispatcher.d/pre-down.d/
+	install -d $(DESTDIR)/etc/NetworkManager/dispatcher.d/no-wait.d/
+	ln -sf /usr/lib/qubes/publish-bridge \
+		$(DESTDIR)/etc/NetworkManager/dispatcher.d/no-wait.d/qubes-bridge
 
-install-vm: install-common install-networkmanager
+install-systemd:
+	install -d $(DESTDIR)$(UNITDIR)
+	install -m 0644 systemd/qubes-publish-bridges.service \
+		$(DESTDIR)$(UNITDIR)/qubes-publish-bridges.service
 
+install-vm: install-common install-networkmanager install-systemd
 install-rh: install-vm
-
-install-deb: install-vm install-networking
+install-deb: install-vm
+install: install-vm

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# qubes-core-agent-linux-addon-bridge-device
+
+Agent-side component of the Qubes OS bridge device addon.  Install this in
+any backend qube whose bridge interfaces you want to expose to other qubes as
+attachable network devices.
+
+For the dom0/adminvm side see
+[qubes-core-admin-addon-bridge-device](https://github.com/QubesOS/qubes-core-admin-addon-bridge-device).
+
+## How it works
+
+The package installs `/usr/lib/qubes/publish-bridge`, a NetworkManager
+dispatcher script that writes bridge metadata into QubesDB:
+
+```
+/qubes-bridge-devices/<bridge-name>/desc   "<name> (bridge_ports: <p1> <p2> ...)"
+```
+
+dom0 watches these keys and presents each bridge as a `bridge`-class device
+via `admin.vm.device.bridge.Available`.
+
+### NM dispatcher events handled
+
+The script is installed as a non-blocking NM dispatcher
+(`no-wait.d/qubes-bridge`) so it never delays network operations.
+
+| NM action   | `$DEVICE_IFACE` | `$MASTER_IFACE` | Effect |
+|-------------|-----------------|-----------------|--------|
+| `up`        | the bridge      | (none)          | Publish bridge with current port list |
+| `pre-down`  | the bridge      | (none)          | Unpublish bridge before it disappears |
+| `slave-up`  | enslaved port   | the bridge      | Re-publish bridge to update port list |
+| `slave-down`| released port   | the bridge      | Re-publish bridge to update port list |
+
+### Boot-time publishing
+
+`qubes-publish-bridges.service` (systemd, one-shot) calls
+`publish-bridge --all` after `network.target` to catch bridges that exist
+at boot before NetworkManager activates them (e.g. bridges created by other
+systemd services or persistent kernel configurations).

--- a/debian/control
+++ b/debian/control
@@ -2,21 +2,33 @@ Source: qubes-core-agent-linux-addon-bridge-device
 Section: admin
 Priority: optional
 Maintainer: Frédéric Pierret <frederic.pierret@qubes-os.org>
+Rules-Requires-Root: no
 Standards-Version: 3.9.8
 Homepage: https://www.qubes-os.org/
-Build-Depends: debhelper (>= 9~), quilt
+Build-Depends: debhelper (>= 9~), make
 
 Package: qubes-core-agent-bridge-device
 Architecture: any
-Depends: bridge-utils
-Description: qubes-core-agent-linux extension for handling Bridge Device
-
-Package: qubes-core-agent-bridge-device-networking
-Architecture: any
-Depends: qubes-core-agent-bridge-device
-Description: qubes-core-agent-linux extension for handling Bridge Device with 'ifupdown'
+Depends: qubes-core-agent, bridge-utils
+Description: Qubes agent extension for publishing bridge network devices
+ Installs the publish-bridge script so that bridge interfaces present in
+ a backend qube are advertised to dom0/adminvm via QubesDB
+ (/qubes-bridge-devices/*).  Any qube can then attach one of these bridges
+ to another qube via the standard Admin API (admin.vm.device.bridge.*).
 
 Package: qubes-core-agent-bridge-device-network-manager
 Architecture: any
-Depends: qubes-core-agent-bridge-device, network-manager
-Description: qubes-core-agent-linux extension for handling Bridge Device with 'NetworkManager'
+Depends: qubes-core-agent-bridge-device (= ${binary:Version}), network-manager
+Description: Bridge device publishing hooks for NetworkManager
+ NetworkManager dispatcher hook installed in no-wait.d/ so that bridge
+ interfaces managed by NM are published to QubesDB on activation (up),
+ removed on deactivation (pre-down), and kept current as ports are
+ enslaved or released (slave-up / slave-down).
+
+Package: qubes-core-agent-bridge-device-systemd
+Architecture: any
+Depends: qubes-core-agent-bridge-device (= ${binary:Version}), systemd
+Description: Bridge device publishing service for systemd
+ A systemd one-shot service (qubes-publish-bridges.service) that publishes
+ all bridge interfaces present at boot time to QubesDB.  Useful for bridges
+ configured statically that are not activated through NetworkManager.

--- a/debian/qubes-core-agent-bridge-device-network-manager.install
+++ b/debian/qubes-core-agent-bridge-device-network-manager.install
@@ -1,2 +1,1 @@
-etc/NetworkManager/dispatcher.d/pre-up.d/publish-bridge
-etc/NetworkManager/dispatcher.d/pre-down.d/publish-bridge
+etc/NetworkManager/dispatcher.d/no-wait.d/qubes-bridge

--- a/debian/qubes-core-agent-bridge-device-networking.install
+++ b/debian/qubes-core-agent-bridge-device-networking.install
@@ -1,2 +1,0 @@
-etc/network/if-up.d/publish-bridge
-etc/network/if-down.d/publish-bridge

--- a/debian/qubes-core-agent-bridge-device-systemd.install
+++ b/debian/qubes-core-agent-bridge-device-systemd.install
@@ -1,0 +1,1 @@
+usr/lib/systemd/system/qubes-publish-bridges.service

--- a/debian/qubes-core-agent-bridge-device.install
+++ b/debian/qubes-core-agent-bridge-device.install
@@ -1,1 +1,2 @@
 usr/lib/qubes/publish-bridge
+usr/lib/qubes/harden-bridge

--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,4 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-
-# Uncomment this to turn on verbose mode.
-#export DH_VERBOSE=1
 
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
@@ -13,7 +9,7 @@ export DESTDIR=$(shell readlink -m .)/debian/tmp
 	dh $@
 
 override_dh_auto_install:
-	make install-deb
+	make install-deb DESTDIR=$(DESTDIR)
 
 override_dh_install:
 	dh_install --fail-missing

--- a/network/harden-bridge
+++ b/network/harden-bridge
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Apply security hardening to a Qubes bridge interface.
+# Usage: harden-bridge <bridge>
+#
+# Safe to call multiple times; nftables table creation is idempotent.
+
+BRIDGE="${1:?Usage: harden-bridge <bridge>}"
+[[ -d "/sys/class/net/$BRIDGE/bridge" ]] || exit 0
+
+# Disable bridge netfilter so bridged L2 traffic does not pass through the
+# host's ip/ip6tables chains (prevents masquerade from rewriting source IPs).
+# Load the module first so the sysctl path exists before we write to it.
+modprobe br_netfilter 2>/dev/null || true
+echo 0 > /proc/sys/net/bridge/bridge-nf-call-iptables
+echo 0 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+echo 0 > /proc/sys/net/bridge/bridge-nf-call-arptables
+
+# STP off: no physical loops; prevents BPDUs from VMs disrupting topology.
+ip link set "$BRIDGE" type bridge stp_state 0
+
+# Shorten FDB aging to narrow the window for stale MAC entries.
+ip link set "$BRIDGE" type bridge ageing_time 3000  # 30 s (units: centiseconds)
+
+# Disable IGMP/MLD snooping -- isolation bridges carry no multicast routing.
+ip link set "$BRIDGE" type bridge mcast_snooping 0
+
+# No proxy ARP, no ICMP redirects on the bridge IP interface.
+for _key in proxy_arp accept_redirects send_redirects; do
+    echo 0 > "/proc/sys/net/ipv4/conf/$BRIDGE/$_key" 2>/dev/null || true
+done
+
+# Bridge-family table: filter L2/L3 traffic arriving on VM vif ports.
+# Idempotent: skip creation if the table already exists.
+if ! nft list table bridge qubes-isolation >/dev/null 2>&1; then
+    nft -f - << 'EOF'
+table bridge qubes-isolation {
+    chain prerouting {
+        type filter hook prerouting priority -300; policy accept;
+        iifname "vif*" goto vif-in
+    }
+
+    chain vif-in {
+        # Drop IEEE 802.1D reserved multicast range (STP/RSTP/MSTP, 802.1X,
+        # LACP, LLDP, ...). Bit-mask: 01:80:C2:00:00:00-0F.
+        ether daddr & ff:ff:ff:ff:ff:f0 == 01:80:c2:00:00:00 drop
+
+        # Drop IPv6 RA (134) and RS (133) -- VMs must not claim to be gateways.
+        ip6 nexthdr icmpv6 icmpv6 type { 133, 134 } drop
+
+        # Rate-limit ARP per ingress port to suppress flooding and bound
+        # the rate at which a compromised VM can poison neighbour caches.
+        ether type arp \
+            meter arp-ratelimit { iifname limit rate 20/second burst 40 packets } \
+            accept
+        ether type arp drop
+
+        # Rate-limit DHCP (UDP dport 67) per port.
+        # No DHCP server on isolation bridges; prevents starvation floods.
+        ip protocol udp udp dport 67 \
+            meter dhcp-ratelimit { iifname limit rate 5/second burst 10 packets } \
+            accept
+        ip protocol udp udp dport 67 drop
+    }
+}
+EOF
+fi
+
+# Inet-family table: block L3 routing between bridge interfaces.
+# If ip_forward is enabled, this prevents traffic leaking from one bridge
+# (e.g., br-dev) to another (e.g., br-prod) via the host routing table.
+if ! nft list table inet qubes-bridge-forward >/dev/null 2>&1; then
+    nft -f - << 'EOF'
+table inet qubes-bridge-forward {
+    chain forward {
+        type filter hook forward priority filter - 1; policy accept;
+        # Drop any routed traffic where both ingress and egress are bridges.
+        iifname "br-*" oifname "br-*" drop
+    }
+}
+EOF
+fi

--- a/network/publish-bridge
+++ b/network/publish-bridge
@@ -1,28 +1,64 @@
 #!/bin/bash
+# NetworkManager dispatcher: publish bridge interfaces to QubesDB.
+#
+# Installed as:
+#   /etc/NetworkManager/dispatcher.d/no-wait.d/qubes-bridge -> publish-bridge
+#
+# Also invoked with --all by qubes-publish-bridges.service at boot to
+# publish every bridge already present in the system.
 
-# NetworkManager defines 'IF' and 'STATUS'
-if [ -z "$IFACE" ] && [ -n "$1" ]; then
-    IFACE="$1"
+command -v qubesdb-write >/dev/null 2>&1 || exit 0
+command -v qubesdb-rm   >/dev/null 2>&1 || exit 0
+
+HARDEN=/usr/lib/qubes/harden-bridge
+
+_publish() {
+    local bridge="$1"
+
+    # Only act on real bridge interfaces.
+    [[ -d "/sys/class/net/$bridge/bridge" ]] || return 0
+
+    local ports=()
+    for port in /sys/class/net/"$bridge"/brif/*; do
+        [[ -e "$port" ]] || break
+        ports+=("$(basename "$port")")
+    done
+
+    local desc="$bridge (bridge_ports: ${ports[*]})"
+    # Remove stale entry first so watchers always see a clean write.
+    qubesdb-rm  "/qubes-bridge-devices/$bridge/" 2>/dev/null || true
+    qubesdb-write "/qubes-bridge-devices/$bridge/desc" "$desc" || true
+}
+
+_unpublish() {
+    local bridge="$1"
+    qubesdb-rm "/qubes-bridge-devices/$bridge/" 2>/dev/null || true
+}
+
+if [[ "$1" == "--all" ]]; then
+    for sysfs_bridge in /sys/class/net/*/bridge; do
+        [[ -d "$sysfs_bridge" ]] || continue
+        br="$(basename "$(dirname "$sysfs_bridge")")"
+        [[ -x "$HARDEN" ]] && "$HARDEN" "$br"
+        _publish "$br"
+    done
+    exit 0
 fi
 
-if [ -z "$MODE" ] && [ -n "$2" ]; then
-    MODE="$2"
-fi
+# DEVICE_IFACE is exported by NM and is authoritative; fall back to $1.
+IFACE="${DEVICE_IFACE:-$1}"
+ACTION="$2"
 
-if [ "$MODE" == "start" ] || [ "$MODE" == "pre-up" ]; then
-# Publish bridge name interface into qubesdb in order to inform @adminvm
-# of bridges availables in the current VM
-    if [ -e "/sys/class/net/$IFACE/bridge" ]; then
-        iface_bridge=()
-        for iface in /sys/class/net/"$IFACE"/brif/*
-        do
-            [[ -e "$iface" ]] || break
-            iface_bridge+=("$(basename "$iface")")
-        done
-        desc="$IFACE (bridge_ports: $iface_bridge)"
-        qubesdb-rm "/qubes-bridge-devices/$IFACE/"
-        qubesdb-write "/qubes-bridge-devices/$IFACE/desc" "$desc"
-    fi
-elif [ "$MODE" == "stop" ] || [ "$MODE" == "pre-down" ]; then
-    qubesdb-rm "/qubes-bridge-devices/$IFACE/"
-fi
+case "$ACTION" in
+    up)
+        [[ -x "$HARDEN" ]] && "$HARDEN" "$IFACE"
+        _publish "$IFACE"
+        ;;
+    pre-down)
+        _unpublish "$IFACE"
+        ;;
+    slave-up|slave-down)
+        # MASTER_IFACE is set by NM for slave-* events.
+        [[ -n "$MASTER_IFACE" ]] && _publish "$MASTER_IFACE"
+        ;;
+esac

--- a/rpm_spec/qubes-core-agent-linux-bridge-device.spec.in
+++ b/rpm_spec/qubes-core-agent-linux-bridge-device.spec.in
@@ -1,39 +1,86 @@
-Name:		qubes-core-agent-bridge-device
-Version:	@VERSION@
-Release:	1%{?dist}
-Summary:	qubes-core-agent-linux extension for handling Bridge Device
+Name:           qubes-core-agent-bridge-device
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Qubes agent extension for publishing bridge network devices
 
-Group:		Qubes
-License:	GPLv2+
-URL:		https://www.qubes-os.org
-Source0:    %{name}-%{version}.tar.gz
+Group:          Qubes
+License:        GPLv2+
+URL:            https://www.qubes-os.org
+Source0:        %{name}-%{version}.tar.gz
 
-BuildRequires: make
-Requires: bridge-utils
+BuildArch:      noarch
+BuildRequires:  make
+BuildRequires:  systemd-rpm-macros
+
+Requires:       qubes-core-agent
+Requires:       qubes-db
+Requires:       bridge-utils
 
 %description
-qubes-core-agent-linux extension for handling Bridge Device
+Agent-side extension for the Qubes bridge device addon.  Installs the
+publish-bridge script so that bridge interfaces in a backend qube are
+advertised to dom0/adminvm via QubesDB (/qubes-bridge-devices/*).
+
+Any qube can then attach one of these bridges to another qube using the
+standard Admin API (admin.vm.device.bridge.*).
+
 
 %package network-manager
-Summary: qubes-core-agent-linux extension for handling Bridge Device with 'NetworkManager'
-Requires: qubes-core-agent-bridge-device
-Requires: NetworkManager
+Summary:        Bridge device publishing hooks for NetworkManager
+Requires:       %{name} = %{version}-%{release}
+Requires:       NetworkManager
 
 %description network-manager
-qubes-core-agent-linux extension for handling Bridge Device with 'NetworkManager'
+NetworkManager dispatcher hook installed in no-wait.d/ so that bridge
+interfaces managed by NM are published to QubesDB on activation (up),
+removed on deactivation (pre-down), and kept current when ports are
+enslaved or released (slave-up / slave-down).
+
+
+%package systemd
+Summary:        Bridge device publishing service for systemd
+Requires:       %{name} = %{version}-%{release}
+%{?systemd_requires}
+
+%description systemd
+A systemd one-shot service (qubes-publish-bridges.service) that publishes
+all bridge interfaces present at boot time to QubesDB.  Install alongside
+the network-manager sub-package so that statically-configured bridges are
+also published even if NetworkManager did not activate them.
+
 
 %prep
 %setup -q
 
+
+%build
+# nothing to compile
+
+
 %install
-make install-rh DESTDIR=$RPM_BUILD_ROOT
+make install-vm DESTDIR=$RPM_BUILD_ROOT UNITDIR=%{_unitdir}
+
+
+%post systemd
+%systemd_post qubes-publish-bridges.service
+
+%preun systemd
+%systemd_preun qubes-publish-bridges.service
+
+%postun systemd
+%systemd_postun_with_restart qubes-publish-bridges.service
+
 
 %files
 /usr/lib/qubes/publish-bridge
+/usr/lib/qubes/harden-bridge
 
 %files network-manager
-/etc/NetworkManager/dispatcher.d/pre-up.d/publish-bridge
-/etc/NetworkManager/dispatcher.d/pre-down.d/publish-bridge
+/etc/NetworkManager/dispatcher.d/no-wait.d/qubes-bridge
+
+%files systemd
+%{_unitdir}/qubes-publish-bridges.service
+
 
 %changelog
 @CHANGELOG@

--- a/systemd/qubes-publish-bridges.service
+++ b/systemd/qubes-publish-bridges.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Publish bridge interfaces to QubesDB
+# Run after NM has activated connections so bridge ports are already enumerated.
+After=NetworkManager.service qubes-qrexec-agent.service
+Wants=qubes-qrexec-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/lib/qubes/publish-bridge --all
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- publish-bridge is now a proper NM dispatcher;
- Add --all mode used by the systemd service to publish every bridge present at boot time;
- Add qubes-publish-bridges.service: a oneshot unit that runs publish-bridge --all after the network is up;
- Update Makefile, RPM spec, and Debian packaging;
- Drop ifupdown hooks;
- Add .qubesbuilder and README;
- Add harden-bridge script called by publish-bridge on each bridge interface.